### PR TITLE
Use ubuntu latest

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,10 +8,13 @@ on:
     - cron: '0 0 * * *'
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get -yqq install libmagickwand-dev
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -12,9 +12,6 @@ jobs:
     env:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
     steps:
-      - name: Install dependencies
-        run: |
-          sudo apt-get -yqq install libmagickwand-dev
       - name: Checkout repo
         uses: actions/checkout@v4
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :build do
   gem "httpx"
   gem "icalendar"
   gem "nokogiri"
-  gem "rmagick"
 end
 
 group :nonproduction do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,13 +26,11 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.1-arm64-darwin)
       racc (~> 1.4)
-    observer (0.1.2)
     ostruct (0.6.1)
     parallel (1.26.3)
     parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
-    pkg-config (1.5.8)
     pry (0.15.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -41,9 +39,6 @@ GEM
     regexp_parser (2.9.2)
     rexml (3.3.5)
       strscan
-    rmagick (6.0.1)
-      observer (~> 0.1)
-      pkg-config (~> 1.4)
     rubocop (1.65.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -75,7 +70,6 @@ DEPENDENCIES
   icalendar
   nokogiri
   pry
-  rmagick
   rubocop
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ so there is no automated system available for menus.
 The .ics generation process:
 
 - Parses https://www.pps.net/Page/214 to find menu PDFs
-- Saves them to the repo, along with a PNG to help change tracking
+- Saves them to the repo
 - Parses the PDF using Anthropic LLM into a CSV.
 - Converts the CSV into iCalendar feeds, one for each menu found on the site.
 - Each stage (pdf download, LLM parsing) is cached in the repo.

--- a/lib/pps_food_feed.rb
+++ b/lib/pps_food_feed.rb
@@ -26,7 +26,6 @@ class PpsFoodFeed
   FEEDS_DIR = STATIC_DIR.join("feeds")
   META_DIR = ROOT_DIR.join("meta")
   PDF_DIR = ROOT_DIR.join("pdfs")
-  PNG_DIR = ROOT_DIR.join("pngs")
 
   include Appydays::Configurable
   include Appydays::Loggable

--- a/lib/pps_food_feed/menu_fetcher.rb
+++ b/lib/pps_food_feed/menu_fetcher.rb
@@ -3,7 +3,6 @@
 require "fileutils"
 require "httpx"
 require "nokogiri"
-require "rmagick"
 
 require_relative "meta"
 
@@ -18,7 +17,6 @@ class PpsFoodFeed
     def run
       meta = PpsFoodFeed::Meta.load
       FileUtils.mkdir_p(PpsFoodFeed::PDF_DIR)
-      FileUtils.mkdir_p(PpsFoodFeed::PNG_DIR)
       now = Time.now
       menu_resp = HTTPX.get(MENU_URL).raise_for_status
       menu_html = menu_resp.to_s
@@ -52,27 +50,22 @@ class PpsFoodFeed
         # Note that the etag may change, even when the content is the same (it's just up to Cloudflare),
         # so we MUST hash the file contents to get a persistent 'id' of the PDF.
         pdf_hash = Digest::SHA256.hexdigest(pdf_bytes)[..8]
-        pdf_filename = self.pdf_filename(menu_month, menu_name, pdf_hash)
+        pdf_filename = self.pdf_filename(menu_month, menu_name, pdf_hash).to_s
         if File.exist?(pdf_filename)
           self.logger.debug("menu_pdf_body_unchanged", menu_url:, pdf_hash:)
           next
         end
 
-        png_filename = self.png_filename(menu_month, menu_name, pdf_hash)
         meta.set(menu_name, menu_month, :url, menu_url)
         meta.set(menu_name, menu_month, :fetched_at, now)
         meta.set(menu_name, menu_month, :etag, pdf_resp_etag)
         meta.set(menu_name, menu_month, :latest_hash, pdf_hash)
         File.binwrite(pdf_filename, pdf_bytes)
-        pdf_im = Magick::Image.read(pdf_filename)
-        self.logger.info("converting_to_png", png_filename:)
-        pdf_im.first.write(png_filename)
       end
       meta.save
       return menu_resp
     end
 
     def pdf_filename(month, name, hash) = PpsFoodFeed.menu_filename(PpsFoodFeed::PDF_DIR, month, name, hash, ".pdf")
-    def png_filename(month, name, hash) = PpsFoodFeed.menu_filename(PpsFoodFeed::PNG_DIR, month, name, hash, ".png")
   end
 end

--- a/lib/pps_food_feed/menu_fetcher.rb
+++ b/lib/pps_food_feed/menu_fetcher.rb
@@ -63,7 +63,7 @@ class PpsFoodFeed
         meta.set(menu_name, menu_month, :fetched_at, now)
         meta.set(menu_name, menu_month, :etag, pdf_resp_etag)
         meta.set(menu_name, menu_month, :latest_hash, pdf_hash)
-        File.write(pdf_filename, pdf_bytes)
+        File.binwrite(pdf_filename, pdf_bytes)
         pdf_im = Magick::Image.read(pdf_filename)
         self.logger.info("converting_to_png", png_filename:)
         pdf_im.first.write(png_filename)


### PR DESCRIPTION
Imagemagick pdf conversion won't work on 22.04 without some workarounds.
See https://stackoverflow.com/questions/52998331/imagemagick-security-policy-pdf-blocking-conversion